### PR TITLE
refactor(图片管理): 将封面图片统一从 dictionaries.js 获取并移除本地映射

### DIFF
--- a/components/textbook-selector/index.js
+++ b/components/textbook-selector/index.js
@@ -61,12 +61,7 @@ Component({
     loadTextbooks() {
       const db = require('../../database/dictionaries.js').dictionaries;
       const textbooks = db.map(dict => {
-        const coverMap = {
-          'everyones_japanese': 'https://free.picui.cn/free/2025/07/20/687bd47160e75.jpg',
-          'liangs_class': 'https://free.picui.cn/free/2025/07/20/687bd4712b75f.jpg',
-          'liangs_intermediate': 'https://free.picui.cn/free/2025/07/20/687bd4715697e.jpg',
-          'duolingguo': 'https://free.picui.cn/free/2025/07/20/687bd47111ec1.jpg'
-        };
+      // 封面图片现在从 dictionaries.js 中直接获取，不再需要本地的 coverMap
         // 初始化词汇量为0
         let wordCount = 0;
         // 创建一个Promise数组来处理所有的异步请求
@@ -104,7 +99,7 @@ Component({
           this.setData({ textbooks: updatedTextbooks });
         });
 
-        return { ...dict, wordCount: '加载中', cover: coverMap[dict.id] || '' };
+        return { ...dict, wordCount: '加载中', cover: dict.cover_image || '' };
       });
       this.setData({ textbooks });
     },

--- a/database/dictionaries.js
+++ b/database/dictionaries.js
@@ -44,6 +44,29 @@ let data = {
                 {"courseNumber":50,"courseTitle":"第50课","lessonFile":"lesson50","description":"大家的日语第50课"}
             ]
         },
+         {
+            "id": "everyones_japanese_intermediate",
+            "name": "大日中级",
+            "description": "大日中级",
+            "cover_image": "https://free.picui.cn/free/2025/07/20/687bd4713099b.jpg",
+            "volumes": [
+                {"id":"volume1","name":"第一册","description":"1-12课","lessons":[1,2,3,4,5,6,7,8,9,10,11,12]}
+            ],
+            "courses": [
+                {"courseNumber":1,"courseTitle":"第1课","lessonFile":"lesson1","description":"中级N3第1课"},
+                {"courseNumber":2,"courseTitle":"第2课","lessonFile":"lesson2","description":"中级N3第2课"},
+                {"courseNumber":3,"courseTitle":"第3课","lessonFile":"lesson3","description":"中级N3第3课"},
+                {"courseNumber":4,"courseTitle":"第4课","lessonFile":"lesson4","description":"中级N3第4课"},
+                {"courseNumber":5,"courseTitle":"第5课","lessonFile":"lesson5","description":"中级N3第5课"},
+                {"courseNumber":6,"courseTitle":"第6课","lessonFile":"lesson6","description":"中级N3第6课"},
+                {"courseNumber":7,"courseTitle":"第7课","lessonFile":"lesson7","description":"中级N3第7课"},
+                {"courseNumber":8,"courseTitle":"第8课","lessonFile":"lesson8","description":"中级N3第8课"},
+                {"courseNumber":9,"courseTitle":"第9课","lessonFile":"lesson9","description":"中级N3第9课"},
+                {"courseNumber":10,"courseTitle":"第10课","lessonFile":"lesson10","description":"中级N3第10课"},
+                {"courseNumber":11,"courseTitle":"第11课","lessonFile":"lesson11","description":"中级N3第11课"},
+                {"courseNumber":12,"courseTitle":"第12课","lessonFile":"lesson12","description":"中级N3第12课"},
+            ]
+        },
         {
             "id": "liangs_class",
             "name": "梁老师初级",

--- a/pages/answer/answer.js
+++ b/pages/answer/answer.js
@@ -415,20 +415,9 @@ Page({
         return dictionary.cover_image;
       }
       
-      console.warn('⚠️ 数据库中没有找到图片，使用后备方案');
-      // 如果数据库中没有图片字段，使用临时的映射表作为后备方案
-      // 注意：顺序调整为与数据库一致，默认使用大家的日语
-      const textbookImages = {
-          'everyones_japanese': 'https://free.picui.cn/free/2025/07/20/687bd47160e75.jpg', // 大家的日本语 - 经典蓝色封面
-          'liangs_class': 'https://free.picui.cn/free/2025/07/20/687bd4712b75f.jpg', // 梁老师初级 - 橙色封面
-          'liangs_intermediate': 'https://free.picui.cn/free/2025/07/20/687bd4715697e.jpg', // 梁老师中级 - 红色封面
-          'duolingguo': 'https://free.picui.cn/free/2025/07/20/687bd47111ec1.jpg', // 多邻国 - 绿色猫头鹰图标
-      };
-      
-      // 如果找不到对应的图片，使用默认的大家的日语图片
-      const fallbackImage = textbookImages[dictionaryId] || textbookImages['everyones_japanese'];
-      console.log('🔄 使用后备图片:', fallbackImage);
-      return fallbackImage;
+      console.warn('⚠️ 数据库中没有找到图片，使用默认图片');
+      // 如果数据库中没有图片字段，返回默认图片
+      return 'https://free.picui.cn/free/2025/07/20/687bd47160e75.jpg';
     } catch (error) {
       console.error('❌ 获取课本图片失败:', error);
       // 即使出错也返回默认的大家的日语图片

--- a/pages/vocabulary/vocabulary.js
+++ b/pages/vocabulary/vocabulary.js
@@ -23,12 +23,7 @@ Page({
    */
   prepareData() {
     const db = require('../../database/dictionaries.js').dictionaries;
-    const coverMap = {
-      'everyones_japanese': 'https://free.picui.cn/free/2025/07/20/687bd47160e75.jpg',
-      'liangs_class': 'https://free.picui.cn/free/2025/07/20/687bd4712b75f.jpg',
-      'liangs_intermediate': 'https://free.picui.cn/free/2025/07/20/687bd4715697e.jpg',
-      'duolingguo': 'https://free.picui.cn/free/2025/07/20/687bd47111ec1.jpg'
-    };
+    // 封面图片现在从 dictionaries.js 中直接获取，不再需要本地的 coverMap
 
     // 显示加载状态
     this.setData({
@@ -54,7 +49,7 @@ Page({
         progress: progress,
         learnedCount: learningProgress.learnedCount,
         totalCount: totalWordCount,
-        cover: coverMap[dict.id] || ''
+        cover: dict.cover_image || ''
       };
     })());
 


### PR DESCRIPTION
移除多个组件中的本地封面图片映射表，统一从 dictionaries.js 中获取封面图片
当数据库中没有图片时，使用默认图片替代复杂的后备方案